### PR TITLE
fix: CORS problem

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,11 @@ JitsiMeetJS.init(); // how do we know this ran?
 //   useNicks: false,
 // };
 
+console.log('connectionConfig', config)
 // appId=null, token=null, options
+// setting a serviceUrl on our config and specifying the use of wss instead
+// of bosh seems to make all the red stuff go away
+config.serviceUrl = config.websocket || config.bosh
 const connection = new JitsiMeetJS.JitsiConnection(null, undefined, config);
 
 // provide a way for us to know if a connection is established,


### PR DESCRIPTION
Integrate this change because it will circumvent the CORS issue associated with trying to create a bosh based connection to the URI /http-bind and use wss protocol instead by adding a single line of code, i.e. setting config.serviceUrl = config.websocket - khu with :sparkles:

Partially addresses #1 