### PR TITLE
feat: make a join link at domain/some-default-room

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ async function jitsiInit() {
   // setting a serviceUrl on our config and specifying the use of wss instead
   // of bosh seems to make all the red stuff go away
   config.serviceUrl = config.websocket || config.bosh;
+  config.serviceUrl += '?room=some-default-room';
 
   /* CONNECTION EVENT HANDLERS */
   // provide a way for us to know if a connection is established,


### PR DESCRIPTION
- e.g. `meet.jit.si/some-default-room` in our case
- because we need to provide a link for multiple people to join
- accomplished by modifying serviceUrl with a URL query param
  ?room=some-default-room
- outstanding questions: why does this work like this? what is going on
  when we fail to specify a room parameter? is there a default room URL
created?
- takeaway: not clear why this accomplishes our stated goals -- task for
  later